### PR TITLE
Show allowed start positions

### DIFF
--- a/src/game/car.js
+++ b/src/game/car.js
@@ -1,15 +1,11 @@
 var Paper = require('paper');
 
 export default class Car {
-  constructor(scale, startPosition){
+  constructor(scale){
     this.scale = scale;
     this.positions = [];
     this.isAlive = true;
     this.isInEndZone = false;
-
-    if(startPosition) {
-      this.positions.push(startPosition);
-    }
   }
 
   get position() {
@@ -32,7 +28,7 @@ export default class Car {
   }
 
   get moves() {
-    return this.positions.length - 1;
+    return Math.max(this.positions.length - 1, 0);
   }
 
   getPossibleMoves() {
@@ -51,6 +47,18 @@ export default class Car {
   }
 
   move(position) {
+    if(!this.position) {
+      throw 'Cannot move, has no start position';
+    }
+
+    this.positions.push(position);
+  }
+
+  setStartPosition(position) {
+    if(this.position) {
+      throw 'Cannot set start position, already has position';
+    }
+
     this.positions.push(position);
   }
 }

--- a/src/game/car.js
+++ b/src/game/car.js
@@ -3,14 +3,21 @@ var Paper = require('paper');
 export default class Car {
   constructor(scale, startPosition){
     this.scale = scale;
-    this.positions = [startPosition];
-    this.direction = new Paper.Point(0, 0);
+    this.positions = [];
     this.isAlive = true;
     this.isInEndZone = false;
+
+    if(startPosition) {
+      this.positions.push(startPosition);
+    }
   }
 
   get position() {
-    return this.positions[this.positions.length - 1];
+    if(this.positions.length > 0) {
+      return this.positions[this.positions.length - 1];
+    }
+
+    return null;
   }
 
   get moves() {

--- a/src/game/car.test.js
+++ b/src/game/car.test.js
@@ -2,17 +2,17 @@ var Car = require('./car');
 var Paper = require('paper');
 
 describe('Car', function() {
-  it('has initial position', function() {
+  it('has no initial position', function() {
     // Act
-    var car = new Car(1, new Paper.Point(1, 3));
+    var car = new Car(1);
 
     // Assert
-    expect(car.position).toEqual(new Paper.Point(1, 3));
+    expect(car.position).toBeNull();
   });
 
   it('has no initial direction', function() {
     // Act
-    var car = new Car(1, new Paper.Point(2, 1));
+    var car = new Car(1);
 
     // Assert
     expect(car.direction).toEqual(new Paper.Point(0, 0));
@@ -20,15 +20,66 @@ describe('Car', function() {
 
   it('has no initial moves', function() {
     // Act
-    var car = new Car(1, new Paper.Point(0, 0));
+    var car = new Car(1);
 
     // Assert
     expect(car.moves).toEqual(0);
   });
 
+  it('can set start position', function() {
+    // Arrange
+    var car = new Car(1);
+
+    // Act
+    car.setStartPosition(new Paper.Point(9, 8));
+
+    // Assert
+    expect(car.position).toEqual(new Paper.Point(9, 8));
+  });
+
+  it('has no moves after setting start position', function() {
+    // Arrange
+    var car = new Car(1);
+
+    // Act
+    car.setStartPosition(new Paper.Point(7, 3));
+
+    // Assert
+    expect(car.moves).toEqual(0);
+  });
+
+  it('has no direction after setting start position', function() {
+    // Arrange
+    var car = new Car(1);
+
+    // Act
+    car.setStartPosition(new Paper.Point(1, 8));
+
+    // Assert
+    expect(car.direction).toEqual(new Paper.Point(0, 0));
+  });
+
+  it('cannot set start position twice', function() {
+    // Arrange
+    var car = new Car(1);
+    car.setStartPosition(new Paper.Point(5, 4));
+
+    // Act and assert
+    expect(function() { car.setStartPosition(new Paper.Point(7, 2)) }).toThrow();
+  });
+
+  it('cannot move without start position', function() {
+    // Arrange
+    var car = new Car(1);
+
+    // Act and assert
+    expect(function() { car.move(new Paper.Point(6, 5)) }).toThrow();
+  });
+
   it('can move', function() {
     // Arrange
-    var car = new Car(1, new Paper.Point(1, 1));
+    var car = new Car(1);
+    car.setStartPosition(new Paper.Point(1, 1));
 
     // Act
     car.move(new Paper.Point(3, 3));
@@ -49,7 +100,7 @@ describe('Car', function() {
 
   it('calculates correct possible moves', function() {
     // Arrange
-    var car = new Car(1, new Paper.Point(1, 1));
+    var car = new Car(1);
 
     // Act
     var possibleMoves = car.getPossibleMoves();

--- a/src/game/game.js
+++ b/src/game/game.js
@@ -13,6 +13,10 @@ export default class Game{
     this.start = Paper.project.importJSON(map.start);
     this.end = Paper.project.importJSON(map.end);
     this.currentPlayerIndex = 0;
+
+    for (var i = 0; i < nbrOfPlayers; i++) {
+      this.players.push(new Car(this.scale));
+    }
   }
 
   get currentPlayer(){
@@ -66,10 +70,6 @@ export default class Game{
     }
 
     return startingPoints;
-  }
-
-  addPlayer(point){
-    this.players.push(new Car(this.scale, point));
   }
 
   movePlayer(position){

--- a/src/game/game.js
+++ b/src/game/game.js
@@ -35,7 +35,9 @@ export default class Game{
       });
     } else {
       this.getAllowedStartPositions().forEach(move => {
-        vectorsForControls.push(move);
+        if(!this.isPositionOccupied(move)) {
+          vectorsForControls.push(move);
+        }
       });
     }
 
@@ -105,10 +107,14 @@ export default class Game{
   }
 
   isAllowedPosition(position) {
-    var carsOnThisPosition = this.players.filter(p => p.position && p.position.clone().subtract(position).length === 0);
-    var noOtherCars = carsOnThisPosition.length === 0;
+    var positionOccupied = this.isPositionOccupied(position);
     var isOnTrack = this.track.contains(position);
-    return noOtherCars && isOnTrack;
+    return !positionOccupied && isOnTrack;
+  }
+
+  isPositionOccupied(position) {
+    var carsOnThisPosition = this.players.filter(p => p.position && p.position.clone().subtract(position).length === 0);
+    return carsOnThisPosition.length !== 0;
   }
 
   isInZone(zone, position){

--- a/src/game/game.js
+++ b/src/game/game.js
@@ -28,17 +28,13 @@ export default class Game{
     var vectorsForControls = [];
 
     if(player.position) {
-      player.getPossibleMoves().forEach(move => {
-        if(this.isAllowedPosition(move)) {
-          vectorsForControls.push(move);
+      player.getPossibleMoves().forEach(position => {
+        if(!this.isPositionOccupied(position) && this.track.contains(position)) {
+          vectorsForControls.push(position);
         }
       });
     } else {
-      this.getAllowedStartPositions().forEach(move => {
-        if(!this.isPositionOccupied(move)) {
-          vectorsForControls.push(move);
-        }
-      });
+      vectorsForControls = this.getAllowedStartPositions();
     }
 
     if(vectorsForControls.length === 0) {
@@ -63,7 +59,7 @@ export default class Game{
     for (var x = x_start; x <= x_end; x += scale) {
       for (var y = y_start; y <= y_end; y += scale) {
         var point = new Paper.Point(x, y);
-        if(this.start.contains(point)) {
+        if(this.start.contains(point) && !this.isPositionOccupied(point)) {
           startingPoints.push(point);
         }
       }
@@ -104,12 +100,6 @@ export default class Game{
     if(this.currentPlayerIndex === this.players.length) {
       this.currentPlayerIndex = 0;
     }
-  }
-
-  isAllowedPosition(position) {
-    var positionOccupied = this.isPositionOccupied(position);
-    var isOnTrack = this.track.contains(position);
-    return !positionOccupied && isOnTrack;
   }
 
   isPositionOccupied(position) {

--- a/src/game/game.js
+++ b/src/game/game.js
@@ -25,7 +25,7 @@ export default class Game{
 
   setVectorsForControls(){
     var player = this.currentPlayer;
-    var allowedMoves = [];
+    var vectorsForControls = [];
 
     if(player.position) {
       console.log('Player has start position, calculating possible moves');
@@ -44,10 +44,10 @@ export default class Game{
       console.log(vectorsForControls);
     }
 
-    if(allowedMoves.length === 0) {
+    if(vectorsForControls.length === 0) {
       player.isAlive = false;
     } else {
-      this.vectorsForControlsStream.push(allowedMoves);
+      this.vectorsForControlsStream.push(vectorsForControls);
     }
   }
 

--- a/src/game/game.js
+++ b/src/game/game.js
@@ -27,17 +27,52 @@ export default class Game{
     var player = this.currentPlayer;
     var vectorsForControls = [];
 
-    player.getPossibleMoves().forEach(move => {
-      if(this.isAllowedPosition(move.absolute)) {
+    if(player.position) {
+      console.log('Player has start position, calculating possible moves');
+      player.getPossibleMoves().forEach(move => {
+        if(this.isAllowedPosition(move)) {
+          vectorsForControls.push(move);
+        }
+      });
+    } else {
+      console.log('Player doesnt have start position, calculating possible start positions');
+      this.getAllowedStartPositions().forEach(move => {
         vectorsForControls.push(move);
-      }
-    });
+      });
+
+      console.log('Found ' + vectorsForControls.length + ' possible start positions');
+      console.log(vectorsForControls);
+    }
 
     if(vectorsForControls.length === 0) {
       player.isAlive = false;
     } else {
       this.vectorsForControlsStream.push(vectorsForControls);
     }
+  }
+
+  getAllowedStartPositions() {
+    var scale = this.scale;
+    var bounds = this.start.bounds;
+
+    var x_start = Math.ceil(bounds.left / scale) * scale;
+    var x_end = Math.floor(bounds.right / scale) * scale;
+
+    var y_start = Math.ceil(bounds.top / scale) * scale;
+    var y_end = Math.floor(bounds.bottom / scale) * scale;
+
+    var startingPoints = [];
+
+    for (var x = x_start; x <= x_end; x += scale) {
+      for (var y = y_start; y <= y_end; y += scale) {
+        var point = new Paper.Point(x, y);
+        if(this.start.contains(point)) {
+          startingPoints.push(point);
+        }
+      }
+    }
+
+    return startingPoints;
   }
 
   addPlayer(point){
@@ -75,7 +110,7 @@ export default class Game{
   }
 
   isAllowedPosition(position) {
-    var carsOnThisPosition = this.players.filter(p => p.position.clone().subtract(position).length === 0);
+    var carsOnThisPosition = this.players.filter(p => p.position && p.position.clone().subtract(position).length === 0);
     var noOtherCars = carsOnThisPosition.length === 0;
     var isOnTrack = this.track.contains(position);
     return noOtherCars && isOnTrack;

--- a/src/game/game.js
+++ b/src/game/game.js
@@ -28,20 +28,15 @@ export default class Game{
     var vectorsForControls = [];
 
     if(player.position) {
-      console.log('Player has start position, calculating possible moves');
       player.getPossibleMoves().forEach(move => {
         if(this.isAllowedPosition(move)) {
           vectorsForControls.push(move);
         }
       });
     } else {
-      console.log('Player doesnt have start position, calculating possible start positions');
       this.getAllowedStartPositions().forEach(move => {
         vectorsForControls.push(move);
       });
-
-      console.log('Found ' + vectorsForControls.length + ' possible start positions');
-      console.log(vectorsForControls);
     }
 
     if(vectorsForControls.length === 0) {

--- a/src/game/game.js
+++ b/src/game/game.js
@@ -74,7 +74,13 @@ export default class Game{
 
   movePlayer(position){
     var player = this.currentPlayer;
-    player.move(position);
+    if(player.position) {
+      player.move(position);
+    }
+    else {
+      player.setStartPosition(position);
+    }
+
     this.playerPositionStream.push({playerIndex: this.currentPlayerIndex, position: player.position});
 
     if(this.isInZone(this.end, player.position)){

--- a/src/views/gameGui/gameGui.js
+++ b/src/views/gameGui/gameGui.js
@@ -133,7 +133,7 @@ export default class GameGui{
       bounds = bounds.include(this.game.currentPlayer.position);
     }
 
-    view.setView(playerBounds.expand(200));
+    view.setView(bounds.expand(200));
   }
 
   setViewToTrack(){

--- a/src/views/gameGui/gameGui.js
+++ b/src/views/gameGui/gameGui.js
@@ -24,7 +24,7 @@ export default class GameGui{
     this.foreGround = new Paper.Group([this.controls]);
     this.course = new Paper.Group();
     this.mouseControls = new Paper.Tool();
-    this.mouseControls.onMouseDown = e => this.addPlayerClickEvent(e);
+    //this.mouseControls.onMouseDown = e => this.addPlayerClickEvent(e);
 
     this.game = new Game(params.map, params.nrbOfPlayers);
     this.game.vectorsForControlsStream.onValue(controls => this.drawControls(controls));
@@ -58,6 +58,13 @@ export default class GameGui{
 
     this.clickListenerHandler = new ClickListenerHandler();
     this.clickListenerHandler.add(endGameButton, () => this.endGameButtonListener());
+
+    for (var i = 0; i < this.nbrOfPlayers; i++) {
+      this.game.addPlayer();
+      this.players.push(new Player(this.playerConfigs.pop()));
+    }
+
+    this.startGame();
   }
 
   get currentPlayer(){
@@ -66,7 +73,7 @@ export default class GameGui{
 
   addPlayerClickEvent(event){
     audio.playClick();
-    
+
     var scale = this.game.scale;
     var x = Math.round(event.point.x / scale) * scale;
     var y = Math.round(event.point.y / scale) * scale;
@@ -78,30 +85,6 @@ export default class GameGui{
         this.startGame();
       }
     }
-  }
-
-  getAllowedStartPositions() {
-    var scale = this.game.scale;
-    var bounds = this.game.start.bounds;
-
-    var x_start = Math.ceil(bounds.left / scale) * scale;
-    var x_end = Math.floor(bounds.right / scale) * scale;
-
-    var y_start = Math.ceil(bounds.top / scale) * scale;
-    var y_end = Math.floor(bounds.bottom / scale) * scale;
-
-    var startingPoints = [];
-
-    for (var x = x_start; x <= x_end; x += scale) {
-      for (var y = y_start; y <= y_end; y += scale) {
-        var point = new Paper.Point(x, y);
-        if(this.game.start.contains(point)) {
-          startingPoints.push(point);
-        }
-      }
-    }
-
-    return startingPoints;
   }
 
   addPlayer(point){

--- a/src/views/gameGui/gameGui.js
+++ b/src/views/gameGui/gameGui.js
@@ -24,7 +24,6 @@ export default class GameGui{
     this.foreGround = new Paper.Group([this.controls]);
     this.course = new Paper.Group();
     this.mouseControls = new Paper.Tool();
-    //this.mouseControls.onMouseDown = e => this.addPlayerClickEvent(e);
 
     this.game = new Game(params.map, params.nrbOfPlayers);
     this.game.vectorsForControlsStream.onValue(controls => this.drawControls(controls));
@@ -60,42 +59,16 @@ export default class GameGui{
     this.clickListenerHandler.add(endGameButton, () => this.endGameButtonListener());
 
     for (var i = 0; i < this.nbrOfPlayers; i++) {
-      this.game.addPlayer();
       this.players.push(new Player(this.playerConfigs.pop()));
     }
 
-    this.startGame();
+    this.players.forEach(p => this.foreGround.appendBottom(p.elements));
+    this.mouseControls.onMouseDown = e => this.onMouseDown(e);
+    this.game.startGame();
   }
 
   get currentPlayer(){
     return this.players[this.game.currentPlayerIndex];
-  }
-
-  addPlayerClickEvent(event){
-    audio.playClick();
-
-    var scale = this.game.scale;
-    var x = Math.round(event.point.x / scale) * scale;
-    var y = Math.round(event.point.y / scale) * scale;
-    var point = new Paper.Point(x, y);
-
-    if(this.game.start.contains(point)){
-      this.addPlayer(point);
-      if(this.players.length === this.nbrOfPlayers){
-        this.startGame();
-      }
-    }
-  }
-
-  addPlayer(point){
-    this.game.addPlayer(point);
-    this.players.push(new Player(this.playerConfigs.pop(), point));
-  }
-
-  startGame(){
-    this.players.forEach(p => this.foreGround.appendBottom(p.elements));
-    this.mouseControls.onMouseDown = e => this.onMouseDown(e);
-    this.game.startGame();
   }
 
   onMouseDown(event){

--- a/src/views/gameGui/gameGui.js
+++ b/src/views/gameGui/gameGui.js
@@ -127,7 +127,12 @@ export default class GameGui{
   }
 
   setViewToControls(){
-    var playerBounds = this.controls.bounds.include(this.game.currentPlayer.position);
+    var bounds = this.controls.bounds;
+
+    if(this.game.currentPlayer.position) {
+      bounds = bounds.include(this.game.currentPlayer.position);
+    }
+
     view.setView(playerBounds.expand(200));
   }
 

--- a/src/views/gameGui/gameGui.js
+++ b/src/views/gameGui/gameGui.js
@@ -24,6 +24,7 @@ export default class GameGui{
     this.foreGround = new Paper.Group([this.controls]);
     this.course = new Paper.Group();
     this.mouseControls = new Paper.Tool();
+    this.mouseControls.onMouseDown = e => this.onMouseDown(e);
 
     this.game = new Game(params.map, params.nrbOfPlayers);
     this.game.vectorsForControlsStream.onValue(controls => this.drawControls(controls));
@@ -41,8 +42,6 @@ export default class GameGui{
     this.course.addChild(startArea);
     this.course.addChild(endArea);
     view.addCourse(this.course);
-
-    this.setViewToStart();
 
     this.mousewheelListener = document.addEventListener('mousewheel', event => {
       if(event.wheelDelta === 0) return;
@@ -63,7 +62,6 @@ export default class GameGui{
     }
 
     this.players.forEach(p => this.foreGround.appendBottom(p.elements));
-    this.mouseControls.onMouseDown = e => this.onMouseDown(e);
     this.game.startGame();
   }
 
@@ -87,16 +85,8 @@ export default class GameGui{
     if(shouldZoomOut) {
       this.setViewToTrack();
     } else {
-      if(!this.game.currentPlayer) {
-        this.setViewToStart();
-      } else {
-        this.setViewToControls();
-      }
+      this.setViewToControls();
     }
-  }
-
-  setViewToStart() {
-    view.setView(this.game.start.bounds.expand(200));
   }
 
   setViewToControls(){

--- a/src/views/gameGui/gameGui.js
+++ b/src/views/gameGui/gameGui.js
@@ -80,6 +80,30 @@ export default class GameGui{
     }
   }
 
+  getAllowedStartPositions() {
+    var scale = this.game.scale;
+    var bounds = this.game.start.bounds;
+
+    var x_start = Math.ceil(bounds.left / scale) * scale;
+    var x_end = Math.floor(bounds.right / scale) * scale;
+
+    var y_start = Math.ceil(bounds.top / scale) * scale;
+    var y_end = Math.floor(bounds.bottom / scale) * scale;
+
+    var startingPoints = [];
+
+    for (var x = x_start; x <= x_end; x += scale) {
+      for (var y = y_start; y <= y_end; y += scale) {
+        var point = new Paper.Point(x, y);
+        if(this.game.start.contains(point)) {
+          startingPoints.push(point);
+        }
+      }
+    }
+
+    return startingPoints;
+  }
+
   addPlayer(point){
     this.game.addPlayer(point);
     this.players.push(new Player(this.playerConfigs.pop(), point));

--- a/src/views/gameGui/player.js
+++ b/src/views/gameGui/player.js
@@ -12,8 +12,6 @@ export default class Player{
     });
     this.circles = new Paper.Group();
     this.elements = new Paper.Group([this.path, this.circles]);
-
-    //this.addPosition(position);
   }
 
   addPosition(position){

--- a/src/views/gameGui/player.js
+++ b/src/views/gameGui/player.js
@@ -1,7 +1,7 @@
 var Paper = require('paper');
 
 export default class Player{
-  constructor(config, position){
+  constructor(config){
     this.color = config.color;
     this.name = config.name;
     this.radius = 5;
@@ -13,7 +13,7 @@ export default class Player{
     this.circles = new Paper.Group();
     this.elements = new Paper.Group([this.path, this.circles]);
 
-    this.addPosition(position);
+    //this.addPosition(position);
   }
 
   addPosition(position){


### PR DESCRIPTION
Moved start position logic to game engine (from GUI) which makes it possible to show the same controls for selecting start positions for each player as during game. Players/cars are now created immediately without any position.

![image](https://cloud.githubusercontent.com/assets/6519/11792316/c9a9c196-a2a5-11e5-9e24-2636c8645789.png)
